### PR TITLE
Render questions declaratively in reverse

### DIFF
--- a/public/javascript/modules/get_data.js
+++ b/public/javascript/modules/get_data.js
@@ -3,14 +3,13 @@ import { renderAantalVragenText } from './render_api_data.js'
 import { vragenlijst_voorbeeld_json } from './vragenlijst.js'
 
 export async function getData() {
-//   showLoadingState()
+  //   showLoadingState()
   const api_url = 'https://fhir.mibplatform.nl/api/Questionnaires/2'
   const response = fetch(api_url)
     .then((response) => { // Check if the response status is OK, if yes return the response data
       if (response.status >= 200 && response.status <= 299) {
         return response.json()
-      }
-      else {
+      } else {
         return vragenlijst_voorbeeld_json; // Fallback
       }
     })
@@ -18,15 +17,17 @@ export async function getData() {
     .then(function(data) {
       console.log(data)
 
-        // hideLoadingState()
-        const aantal_vragen = data['questions'].length;
-                
-        renderAantalVragenText(aantal_vragen)
-        for (let vraag_idx=aantal_vragen-1; vraag_idx>-1; vraag_idx--) {
-          const vraag_object = data['questions'][vraag_idx];
-          renderVraag(vraag_idx,vraag_object);
-        }
+      // hideLoadingState()
+      const aantal_vragen = data['questions'].length;
 
+      renderAantalVragenText(aantal_vragen)
+
+      // Clone and reverse question array to render it in reverse order
+      const vragen = data['questions'].slice().reverse();
+      for (const i in vragen) {
+        const vraag = vragen[i];
+        renderVraag(i, vraag);
+      }
     })
 
     .catch((error) => { // If the response status is not OK


### PR DESCRIPTION
Looping backwards into an array might be confusing. If you reverse the array (after cloning, because javascript _mutates_ the array you reverse) and then just loop normally, you can avoid index errors and have a cleaner loop :) (I haven't tested this so that might be a good idea to do first 🙃).